### PR TITLE
Workaround missing actualHours on ticket records

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -116,6 +116,9 @@ class Dispatcher {
             }).then(result => {
                 let tickets = {};
                 for (let ticket of result) {
+                    if (!('actualHours' in ticket)) {
+                        ticket.actualHours = 0;
+                    }
                     tickets[ticket.id] = ticket;
                 }
 


### PR DESCRIPTION
CW stopped providing `actualHours: 0` on records with no hours yet, causing NaN errors.